### PR TITLE
BackButton Position fix for iPad

### DIFF
--- a/KinoPubAppleClient/Views/Player/PlayerView.swift
+++ b/KinoPubAppleClient/Views/Player/PlayerView.swift
@@ -79,9 +79,10 @@ struct PlayerView: View {
 #if os(macOS)
       .buttonStyle(PlainButtonStyle())
 #endif
-      .frame(width: 70, height: 50)
-      .padding(.leading, 16)
+      .frame(width: 70, height: 70)
+      .padding(.leading, 32)
       .padding(.top, 16)
+      .contentShape(Rectangle())
       Spacer()
     }
     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
Before that, the back button overlapped with the AirDrop button, it was difficult to press the back button, and the sensitivity field of the button was very small, so it was not always adjustable. Moved the button away from AirDrop and increased the field of vision. Changes made to the iPad screen. Signed-off-by: Author Name patrikaskar@gmail.com