### PR TITLE
Fix deprecated Language code

### DIFF
--- a/KinoPubAppleClient/Views/Profile/ProfileModel.swift
+++ b/KinoPubAppleClient/Views/Profile/ProfileModel.swift
@@ -29,7 +29,7 @@ class ProfileModel: ObservableObject {
         self.userService = userService
         self.errorHandler = errorHandler
         self.authState = authState
-        self.selectedLanguage = UserDefaults.standard.string(forKey: "selectedLanguage") ?? Locale.currentLanguageCode
+        self.selectedLanguage = UserDefaults.standard.string(forKey: "selectedLanguage") ?? (Locale.current.language.languageCode?.identifier ?? "en")
     }
     func fetch() {
         Task {

--- a/KinoPubAppleClient/Views/Profile/ProfileView.swift
+++ b/KinoPubAppleClient/Views/Profile/ProfileView.swift
@@ -15,7 +15,7 @@ struct ProfileView: View {
   @EnvironmentObject var errorHandler: ErrorHandler
   @Environment(\.appContext) var appContext
   @StateObject private var model: ProfileModel
-  @AppStorage("selectedLanguage") private var selectedLanguage: String = Locale.currentLanguageCode
+  @AppStorage("selectedLanguage") private var selectedLanguage: String = (Locale.current.language.languageCode?.identifier ?? "en")
 
   @State private var showLogoutAlert: Bool = false
     


### PR DESCRIPTION
The application did not build with an error. The current method for obtaining languageCode is not available in the latest version, updated to the new one