### PR TITLE
Fix bookmarks response decoding and preserve original API decoding errors

### DIFF
--- a/Packages/KinoPubBackend/Sources/KinoPubBackend/Client/APIClient.swift
+++ b/Packages/KinoPubBackend/Sources/KinoPubBackend/Client/APIClient.swift
@@ -47,8 +47,12 @@ public class APIClient {
       if throwDecodingErrorImmediately {
         throw APIClientError.decodingError(error)
       }
-      let result = try decode(BackendError.self, from: data, throwDecodingErrorImmediately: true)
-      throw APIClientError.networkError(result)
+
+      if let backendError = try? JSONDecoder().decode(BackendError.self, from: data) {
+        throw APIClientError.networkError(backendError)
+      }
+
+      throw APIClientError.decodingError(error)
     }
   }
 }

--- a/Packages/KinoPubBackend/Sources/KinoPubBackend/Models/Bookmark.swift
+++ b/Packages/KinoPubBackend/Sources/KinoPubBackend/Models/Bookmark.swift
@@ -15,6 +15,57 @@ public struct Bookmark: Codable {
   public let created: Int
   public let updated: Int
   public var skeleton: Bool?
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case views
+    case count
+    case created
+    case updated
+    case skeleton
+  }
+
+  public init(id: Int,
+              title: String,
+              views: Int,
+              count: String,
+              created: Int,
+              updated: Int,
+              skeleton: Bool? = nil) {
+    self.id = id
+    self.title = title
+    self.views = views
+    self.count = count
+    self.created = created
+    self.updated = updated
+    self.skeleton = skeleton
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    id = try container.decode(Int.self, forKey: .id)
+    title = try container.decode(String.self, forKey: .title)
+    views = try container.decode(Int.self, forKey: .views)
+    created = try container.decode(Int.self, forKey: .created)
+    updated = try container.decode(Int.self, forKey: .updated)
+    skeleton = try container.decodeIfPresent(Bool.self, forKey: .skeleton)
+
+    if let numericCount = try? container.decode(Int.self, forKey: .count) {
+      count = String(numericCount)
+    } else if let stringCount = try? container.decode(String.self, forKey: .count) {
+      count = stringCount
+    } else {
+      throw DecodingError.typeMismatch(
+        String.self,
+        DecodingError.Context(
+          codingPath: container.codingPath + [CodingKeys.count],
+          debugDescription: "Expected bookmark count to be a string or integer."
+        )
+      )
+    }
+  }
 }
 
 public extension Bookmark {

--- a/Packages/KinoPubBackend/Tests/KinoPubBackendTests/APIClientTests.swift
+++ b/Packages/KinoPubBackend/Tests/KinoPubBackendTests/APIClientTests.swift
@@ -22,23 +22,25 @@ class APIClientTests: XCTestCase {
     // Given
     let json = """
         {
-            "access_token": "testToken",
-            "token_type": "bearer",
+            "code": "testCode",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://example.com/activate",
             "expires_in": 12345,
-            "refresh_token": "testRefreshToken"
+            "interval": 5
         }
         """
     sessionMock.data = json.data(using: .utf8, allowLossyConversion: true)
 
     // When
     do {
-      let response: TokenResponse = try await apiClient.performRequest(with: RequestData(path: "/token", method: "GET"), decodingType: TokenResponse.self)
+      let response: VerificationResponse = try await apiClient.performRequest(with: RequestData(path: "/token", method: "GET"), decodingType: VerificationResponse.self)
 
       // Then
-      XCTAssertEqual(response.accessToken, "testToken")
-      XCTAssertEqual(response.tokenType, "bearer")
+      XCTAssertEqual(response.code, "testCode")
+      XCTAssertEqual(response.userCode, "ABCD-1234")
+      XCTAssertEqual(response.verificationUri, "https://example.com/activate")
       XCTAssertEqual(response.expiresIn, 12345)
-      XCTAssertEqual(response.refreshToken, "testRefreshToken")
+      XCTAssertEqual(response.interval, 5)
     } catch {
       XCTFail("Expected successful decoding but got error: \(error)")
     }
@@ -50,12 +52,64 @@ class APIClientTests: XCTestCase {
 
     // When
     do {
-      let _: TokenResponse = try await apiClient.performRequest(with: RequestData(path: "/token", method: "GET"), decodingType: TokenResponse.self)
+      let _: VerificationResponse = try await apiClient.performRequest(with: RequestData(path: "/token", method: "GET"), decodingType: VerificationResponse.self)
       XCTFail("Expected error but got a successful response")
     } catch {
       // Expected behavior
     }
   }
 
-  // ... More tests based on different scenarios
+  func testPerformRequest_WhenBookmarksCountIsNumeric_DecodesResponse() async throws {
+    let json = """
+        {
+            "status": 200,
+            "items": [
+                {
+                    "id": 1920676,
+                    "title": "basket",
+                    "views": 0,
+                    "count": 15,
+                    "created": 1700883333,
+                    "updated": 1713963602
+                }
+            ]
+        }
+        """
+    sessionMock.data = json.data(using: .utf8, allowLossyConversion: true)
+
+    let response: ArrayData<Bookmark> = try await apiClient.performRequest(
+      with: RequestData(path: "/bookmarks", method: "GET"),
+      decodingType: ArrayData<Bookmark>.self
+    )
+
+    XCTAssertEqual(response.items.count, 1)
+    XCTAssertEqual(response.items.first?.count, "15")
+  }
+
+  func testPerformRequest_WhenNonErrorPayloadDecodingFails_ThrowsOriginalDecodingError() async {
+    let json = """
+        {
+            "status": 200,
+            "items": []
+        }
+        """
+    sessionMock.data = json.data(using: .utf8, allowLossyConversion: true)
+
+    do {
+      let _: VerificationResponse = try await apiClient.performRequest(
+        with: RequestData(path: "/token", method: "GET"),
+        decodingType: VerificationResponse.self
+      )
+      XCTFail("Expected decoding error but got a successful response")
+    } catch APIClientError.decodingError(let error) {
+      guard case let DecodingError.keyNotFound(key, _) = error else {
+        XCTFail("Expected missing code decoding error but got \(error)")
+        return
+      }
+
+      XCTAssertEqual(key.stringValue, "code")
+    } catch {
+      XCTFail("Expected decoding error but got \(error)")
+    }
+  }
 }


### PR DESCRIPTION
## What

- Fixed bookmarks response decoding for `/v1/bookmarks`.
- Updated `Bookmark` decoding so `count` can be parsed from either an integer or a string.
- Updated `APIClient` error handling to preserve the original decoding error when the payload is not a backend error response.
- Added tests for:
  - successful decoding when bookmark `count` is numeric
  - returning the original decoding error for non-error payloads

## Why

The bookmarks screen was failing to load even though the backend returned `200 OK`, because the API response contained `count` as a number while the client expected a string.

On top of that, the networking layer tried to decode the same payload as `BackendError` after the first decoding failure, which replaced the real root cause with a misleading `keyNotFound("error")` message in logs.

This change makes bookmark decoding compatible with the backend payload and keeps decoding failures diagnosable.
